### PR TITLE
Make maestro great again

### DIFF
--- a/packages/sandbox/e2e/subflow/stopApp.yaml
+++ b/packages/sandbox/e2e/subflow/stopApp.yaml
@@ -1,0 +1,4 @@
+appId: ${APPID}
+---
+# workaround to handle ios deeplink correctly to run the test
+- stopApp

--- a/packages/sandbox/e2e/visual_regressions_flow.yml
+++ b/packages/sandbox/e2e/visual_regressions_flow.yml
@@ -1,8 +1,18 @@
 appId: ${APPID}
 ---
 - launchApp
-- tapOn: 'Sandbox'
-- tapOn: 'Foundation'
+- stopApp
+- openLink:
+    link: exp://192.168.31.62:19000
+    autoVerify: true
+- tapOn:
+    # bypass expo onboarding modal if you run the test on a fresh env
+    text: 'Got it'
+    optional: true
+- tapOn:
+    # bypass expo onboarding modal if you run the test on a fresh env
+    text: 'Foundation'
+    optional: true
 - tapOn: 'Box >'
 - waitForAnimationToEnd:
     timeout: 10000

--- a/packages/sandbox/e2e/visual_regressions_flow.yml
+++ b/packages/sandbox/e2e/visual_regressions_flow.yml
@@ -1,9 +1,13 @@
 appId: ${APPID}
 ---
-- launchApp
-- stopApp
+- launchApp:
+    stopApp: true # stop the app before launching it
+- runFlow:
+    when:
+      true: ${PLATFORM == 'ios'}
+    file: subflow/stopApp.yaml # workaround to handle ios deeplink correctly to run the test
 - openLink:
-    link: exp://192.168.31.62:19000
+    link: exp://localhost:19000
     autoVerify: true
 - tapOn:
     # bypass expo onboarding modal if you run the test on a fresh env


### PR DESCRIPTION
## Resume

I launch the app then kill it to be able to use the expo deeplink to load the bundler. it's more a workaround than a perfect solution.

The bundler should be already 

## Checklist before requesting a review
- [x] Working on iOS
- [x] Working on Android
- [ ] Integration tests added
- [ ] Visual regressions screenshots are up to date
- [ ] Design validated
