### PR TITLE
fix: yarn sandbox:start:e2e using @nrwl/expo:start executor

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prepare": "husky install",
     "postinstall": "patch-package",
     "sandbox:start": "yarn nx run sandbox:start",
-    "sandbox:start:e2e": "yarn nx run sandbox:start:e2e",
+    "sandbox:start:e2e": "yarn nx run sandbox:start-e2e",
     "sandbox:start:clear": "yarn nx run sandbox:start --clear",
     "sandbox:test": "yarn nx run streamline:test",
     "sandbox:test:visual:ios": "yarn nx run sandbox:test-visual-ios",

--- a/packages/sandbox/project.json
+++ b/packages/sandbox/project.json
@@ -10,6 +10,12 @@
         "port": 8081
       }
     },
+    "start-e2e": {
+      "executor": "@nrwl/expo:start",
+      "options": {
+        "port": 8081
+      }
+    },
     "serve": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Fix interactive mode on expo with NX executor

## Checklist before requesting a review
- [x] Working on iOS
- [x] Working on Android
