### PR TITLE
MarkdownLink: add documentation with JSdoc

### DIFF
--- a/packages/streamline/src/primitives/markdown/markdown-link.tsx
+++ b/packages/streamline/src/primitives/markdown/markdown-link.tsx
@@ -14,6 +14,39 @@ export interface MarkdownProps {
   bodyColor?: ColorTheme;
 }
 
+/**
+ * MarkdownLink
+ *
+ * This component is a wrapper around react-native-markdown-display.
+ * It disables all the formatting except for links.
+ *
+ * It also uses the streamline theme for the colors.
+ *
+ * @param children - markdown text, should use the markdown syntax for links to be tappable: [my link](url)
+ * @param onLinkPress - callback function that fires when a link is pressed, should return a boolean.
+ * @param bodyColor - optional color to use for the body text
+ *
+ * @example
+ * ```typescript
+ * const myText = [link](https://www.google.com)
+ *
+ * const onLinkPress = (url) => {
+ *   if (url) {
+ *     // some custom logic
+ *     return false;
+ *  }
+ *
+ *   // return true to open with `Linking.openURL
+ *   // return false to handle it yourself
+ *   return true
+ * }
+ *
+ * <MarkdownLink onLinkPress={handleLinkPress}>
+ *   {myText}
+ * </MarkdownLink>
+ * ```
+ * */
+
 export function MarkdownLink({
   children,
   onLinkPress,


### PR DESCRIPTION
Related to the github doc: https://github.com/RonRadtke/react-native-markdown-display#handling-links

## Checklist before requesting a review
- [x] Working on iOS
- [x] Working on Android
- [x] Integration tests added
- [x] Visual regressions screenshots are up to date
- [x] Design validated
