### PR TITLE
feat(CardTip): add onLinkPress property

### DIFF
--- a/packages/streamline/package.json
+++ b/packages/streamline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getluko/streamline",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "author": "luko",
   "description": "Luko Design System using react-native for iOS and Android",
   "main": "dist/packages/streamline/index.js",

--- a/packages/streamline/src/components/cards/card-summary/card-summary.types.ts
+++ b/packages/streamline/src/components/cards/card-summary/card-summary.types.ts
@@ -2,8 +2,7 @@ import { CardHeaderProps } from '../../../primitives/card/card-header/card-heade
 import { CardProps } from '../../../primitives/card/card.types';
 import { ColorTheme } from '../../../theme';
 import { Appearance } from '../../../theme/appearance';
-import { ButtonProps } from '../../buttons/button/button.types';
-import { TagProps } from '../../tag/tag.types';
+import { FooterProps } from '../../../types';
 
 export type CardSummaryProps = Pick<
   CardProps,
@@ -47,10 +46,6 @@ export type CardSummaryProps = Pick<
      */
     footer?: FooterProps;
   };
-
-type FooterProps =
-  | (Omit<ButtonProps, 'appearance' | 'pointerEvents'> & { type: 'button' })
-  | (TagProps & { type: 'tag' });
 
 type HeaderColors = {
   rightIconColor: ColorTheme;

--- a/packages/streamline/src/components/cards/card-tip/card-tip.tsx
+++ b/packages/streamline/src/components/cards/card-tip/card-tip.tsx
@@ -12,6 +12,7 @@ export const CardTip = ({
   description,
   iconName,
   animated = true,
+  onLinkPress,
 }: CardTipProps) => {
   const colors = getCardTipColors({ appearance });
   return (
@@ -23,7 +24,10 @@ export const CardTip = ({
     >
       <Icon color={colors.iconColor} iconName={iconName} size="large" />
       <Box marginLeft="md" flex={1}>
-        <MarkdownLink bodyColor={colors.descriptionColor}>
+        <MarkdownLink
+          bodyColor={colors.descriptionColor}
+          onLinkPress={onLinkPress}
+        >
           {description}
         </MarkdownLink>
       </Box>

--- a/packages/streamline/src/components/cards/card-tip/card-tip.types.ts
+++ b/packages/streamline/src/components/cards/card-tip/card-tip.types.ts
@@ -1,4 +1,5 @@
 import { IconsName } from '../../../primitives/icon/icon.types';
+import { MarkdownLinkProps } from '../../../primitives/markdown/markdown-link.types';
 import { ColorTheme } from '../../../theme';
 import { Appearance } from '../../../theme/appearance';
 
@@ -7,6 +8,7 @@ export type CardTipProps = {
   description: string;
   iconName: IconsName;
   animated?: boolean;
+  onLinkPress: MarkdownLinkProps['onLinkPress'];
 };
 
 export type CardTipColors = {

--- a/packages/streamline/src/primitives/markdown/markdown-link.tsx
+++ b/packages/streamline/src/primitives/markdown/markdown-link.tsx
@@ -3,16 +3,11 @@ import MarkdownDisplay, {
 } from '@ronradtke/react-native-markdown-display';
 import React from 'react';
 
-import { ColorTheme, fonts, useStreamlineTheme } from '../../theme';
+import { fonts, useStreamlineTheme } from '../../theme';
 import { colors } from '../../theme/colors';
 import { FontFamily } from '../../theme/fonts';
 import { isIOS } from '../../utils/platform';
-
-export interface MarkdownLinkProps {
-  children: string;
-  onLinkPress?: (url: string) => boolean;
-  bodyColor?: ColorTheme;
-}
+import { MarkdownLinkProps } from './markdown-link.types';
 
 /**
  * MarkdownLink

--- a/packages/streamline/src/primitives/markdown/markdown-link.types.ts
+++ b/packages/streamline/src/primitives/markdown/markdown-link.types.ts
@@ -1,0 +1,7 @@
+import { ColorTheme } from '../../theme';
+
+export interface MarkdownLinkProps {
+  children: string;
+  onLinkPress?: (url: string) => boolean;
+  bodyColor?: ColorTheme;
+}

--- a/packages/streamline/src/types.ts
+++ b/packages/streamline/src/types.ts
@@ -1,3 +1,6 @@
+import { ButtonProps } from './components/buttons/button/button.types';
+import { TagProps } from './components/tag/tag.types';
+
 export { IconsName } from './primitives/icon/icon.types';
 export * from './components/list-items/list-item-value/list-item-value.types';
 export * from './components/list-items/list-item/list-item.types';
@@ -11,3 +14,7 @@ export function isObjKey<T extends object>(key: any, obj: T): key is keyof T {
 export const isDefined = <T>(argument: T | undefined | null): argument is T => {
   return argument != null;
 };
+
+export type FooterProps =
+  | (Omit<ButtonProps, 'appearance' | 'pointerEvents'> & { type: 'button' })
+  | (TagProps & { type: 'tag' });


### PR DESCRIPTION
## Summary
Missing onLinkPress property to support Markdown link press

## Checklist before requesting a review

- [ ] Working on iOS
- [ ] Working on Android
- [ ] Integration tests added

