### PR TITLE
fix(CardTip): make onLinkPress optional

### DIFF
--- a/packages/streamline/src/components/cards/card-tip/card-tip.types.ts
+++ b/packages/streamline/src/components/cards/card-tip/card-tip.types.ts
@@ -8,7 +8,7 @@ export type CardTipProps = {
   description: string;
   iconName: IconsName;
   animated?: boolean;
-  onLinkPress: MarkdownLinkProps['onLinkPress'];
+  onLinkPress?: MarkdownLinkProps['onLinkPress'];
 };
 
 export type CardTipColors = {


### PR DESCRIPTION
## Summary
Even though MarkDownLink onLinkPress can be undefined, the optionality is not inferred correctly upon using CardTip.
...

## Checklist before requesting a review

- [x] Working on iOS
- [x] Working on Android

