### PR TITLE
AppXP: Feedback - HightlightCard - adjust the title margin

### DIFF
--- a/packages/streamline/src/components/cards/card-highlight/card-highlight.tsx
+++ b/packages/streamline/src/components/cards/card-highlight/card-highlight.tsx
@@ -49,14 +49,16 @@ export function CardHighlight({
       <Box padding="md">
         <Box flexDirection="row" justifyContent="space-between">
           {tag ? (
-            <Tag iconName={tag.iconName} text={tag.text} appearance="light" />
+            <Box marginBottom="md">
+              <Tag iconName={tag.iconName} text={tag.text} appearance="light" />
+            </Box>
           ) : null}
           {isLoading || isResolving ? (
             <Spinner color="PURE_WHITE_1000" />
           ) : null}
         </Box>
 
-        <Text variant="titleMediumBold" color={titleColor} marginTop="md">
+        <Text variant="titleMediumBold" color={titleColor}>
           {title}
         </Text>
         {description ? (


### PR DESCRIPTION
## Summary

ticket : [Notion : Awkward space above title on highlight cards](https://www.notion.so/luko/Awkward-space-above-title-on-highlight-cards-4309d849f11d4d68bc27121bc38219a5?pvs=4 )
...

## Checklist before requesting a review

- [x] Working on iOS
- [x] Working on Android
- [ ] Integration tests added
- [ ] Visual regressions screenshots are up to date
- [ ] Design validated

## Screenshots

| iOS                                                                                                                                                                           | Android                                                                                                                                                                           |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/GetLuko/streamline/assets/56963543/57382ef3-bf9a-4866-876b-feaddcacef98" width="300" /> | <img src="https://github.com/GetLuko/streamline/blob/{INSERT_YOUR_BRANCH_NAME}/packages/sandbox/e2e/android/screenshots/{INSERT_YOUR_COMPONENT_NAME}.png?raw=true" width="300" /> |
