### PR TITLE
fix: add right props into NavigationBarTrail component

### DIFF
--- a/packages/streamline/src/components/navigation/navigation-bar-trail/navigation-bar-trail.tsx
+++ b/packages/streamline/src/components/navigation/navigation-bar-trail/navigation-bar-trail.tsx
@@ -117,8 +117,7 @@ export const NavigationBarTrail = ({
         ) : null}
         {right ? (
           <ButtonIcon
-            iconName={right.iconName}
-            accessibilityLabel={right.accessibilityLabel}
+            {...right}
             onPress={right.onPress}
             size="large"
             appearance={appearance}


### PR DESCRIPTION
## Summary
Add the totality of the Right's props inside of NavigationBarTrail component.
Especially TestID
...

## Checklist before requesting a review

- [ ] Working on iOS
- [ ] Working on Android
- [ ] Integration tests added
- [ ] Visual regressions screenshots are up to date
- [ ] Design validated

## Screenshots

| iOS                                                                                                                                                                           | Android                                                                                                                                                                           |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/GetLuko/streamline/blob/{INSERT_YOUR_BRANCH_NAME}/packages/sandbox/e2e/ios/screenshots/{INSERT_YOUR_COMPONENT_NAME}.png?raw=true" width="300" /> | <img src="https://github.com/GetLuko/streamline/blob/{INSERT_YOUR_BRANCH_NAME}/packages/sandbox/e2e/android/screenshots/{INSERT_YOUR_COMPONENT_NAME}.png?raw=true" width="300" /> |
