### PR TITLE
fix(InputSearch): search text padding for some Samsung devices

### DIFF
--- a/src/components/inputs/input-text/components/input-text-primitive.tsx
+++ b/src/components/inputs/input-text/components/input-text-primitive.tsx
@@ -231,6 +231,7 @@ const useStyles = ({
     },
     inputSearchContainer: {
       marginLeft: spacing.xs,
+      padding: 0,
     },
     secureTextEntry: {
       fontFamily: 'System',


### PR DESCRIPTION
## Summary
In the app project (not the sandbox), the text input padding was messy for Samsung A5

## Checklist before requesting a review

- [x] Working on iOS
- [x] Working on Android
- [x] Visual regressions screenshots are up to date
